### PR TITLE
Fix typo 2^31 -> 2^63

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ func main() {
 
 ### Practical maximum of 9 bytes (for security)
 
-For security, to avoid memory attacks, we use a "practical max" of 9 bytes. Though there is no theoretical limit, and future specs can grow this number if it is truly necessary to have code or length values larger than `2^31`. 
+For security, to avoid memory attacks, we use a "practical max" of 9 bytes. Though there is no theoretical limit, and future specs can grow this number if it is truly necessary to have code or length values equal to or larger than `2^63`.
 
 For the forseeable future:
 


### PR DESCRIPTION
This is just the alternate version of https://github.com/multiformats/unsigned-varint/pull/13 which says "equal to or larger than", which I personally find easier to parse.

Please note that this issue got reported several times:

 - https://github.com/multiformats/unsigned-varint/commit/8a6574bd229d9e158dad43acbcea7763b7807362#r21055702
 - https://github.com/core-wg/yang-cbor/issues/13#issuecomment-522970153

This supersedes https://github.com/multiformats/unsigned-varint/pull/13.