### PR TITLE
fix: cleanup spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ This unsigned varint (VARiable INTeger) format is for the use in all the multifo
 
 ## Format
 
-Our unsigned varint is an MSB based unsigned varint.
+Our unsigned varint is a variant of unsigned [LEB128](https://en.wikipedia.org/wiki/LEB128) with some additional restrictions.
+
+Specifically, unlike LEB128:
+
+- Signed numbers are not supported.
+- Leading zeros must be trimmed when encoding and must be rejected when decoding. The only number that can end in a `0x00` is `0`.
 
 ### Spec
 
@@ -21,7 +26,7 @@ The encoding is:
 - there are no signed integers
 - integers are minimally encoded
 
-Examples: 
+Examples:
 
 ```
 1 (0x01)        => 00000001 (0x01)
@@ -40,7 +45,8 @@ bit    # |c 6 5 4 3 2 1 0 |c 5 4 3 2 1 0 7 |c 4 3 2 1 0 7 6 |
 ```
 
 Code that generates this.
-```
+
+```go
 package main
 
 // test program. we can use the go one.
@@ -80,7 +86,7 @@ For the forseeable future:
 - A multiformat spec MAY explicitly declare a smaller maximum when using varints.
 - A multiformat spec MAY NOT explicitly declare a larger maximum when using varints without first changing this spec.
 
-### Main differences from Go Varint
+### Incompatibilities with Go varints
 
 This MSB-based unsigned varint is based on the [varint of the Go standard library](https://golang.org/src/encoding/binary/varint.go), which itself was based on the protocol buffers one.
 
@@ -100,10 +106,7 @@ However, the _minimal_ encoding of 0x1 is `{0x1}`.
 * [Rust](https://github.com/paritytech/unsigned-varint)
 * [JS](https://github.com/chrisdickinson/varint)
 * [PHP](https://github.com/team-acaisia/php-varint)
-
-## Maintainers
-
-Captain: [@jbenet](https://github.com/jbenet).
+* [Go](https://github.com/multiformats/go-varint)
 
 ## Contribute
 


### PR DESCRIPTION
1. It's based on LEB128 (before protobuf was a thing).
2. Make it extra clear that we require "minimal" encoding.
3. Remove maintainers section.
4. Add go-varint. 