### PR TITLE
Add a link to a C implementation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ However, the _minimal_ encoding of 0x1 is `{0x1}`.
 
 * [Rust](https://github.com/paritytech/unsigned-varint)
 * [JS](https://github.com/chrisdickinson/varint)
+* [C](https://github.com/Jorropo/c-ipfs#unsigned-varuint)
 
 ## Maintainers
 


### PR DESCRIPTION
I've added a link to my implementation of varuint in C.